### PR TITLE
Feature/print only

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For any clustered Redis database it is important to mention that only a single n
 ```
 
 Execute the script. Use the -d option to change the duration in minutes the script will wait for running the second set of INFO and INFO COMMANDSTATS commands. By default this flag is set to 5 minutes.
+Use the -po option to print the results in console (when this option is activated the output file will not be created).
 
 By default, the output will be stored in OSStats.xlsx. Use -c option to change the name of output file.
 

--- a/osstats.py
+++ b/osstats.py
@@ -772,6 +772,16 @@ def process_database(config, section, workbook, duration,loop):
     return workbook
 
 
+def print_results(wb):
+    sheet = wb.active
+    print("\n--------------------")
+    for row_num in range(2, sheet.max_row + 1):
+        for col_idx, col in enumerate(sheet.iter_cols(min_row=1, max_row=1)):
+            header_value = col[0].value
+            cell_value = sheet.cell(row=row_num, column=col_idx + 1).value
+            print(f"{header_value}: {cell_value}")
+        print("--------------------\n")
+
 def main():
     if not sys.version_info >= (3, 6):
         print("Please upgrade python to a version at least 3.6")
@@ -800,6 +810,13 @@ def main():
         default="OSStats.xlsx",
         help = "Name of file results are written to. Defaults to OSStats.xlsx"
     )
+    parser.add_argument(
+        "-po",
+        "--print-only",
+        dest="printOnly",
+        action="store_true",
+        help = "Print results only in console"
+    )
     args = parser.parse_args()
 
     if not os.path.isfile(args.configFile):
@@ -821,9 +838,18 @@ def main():
     for section in config.sections():
         wb = process_database(dict(config.items(section)), section, wb, args.duration,loop)
     loop.close()
-    print("\nWriting output file {}".format(args.outputFile))
-    wb.save(args.outputFile)
+
+    if args.printOnly:
+        print_results(wb)
+    else:
+        print("\nWriting output file {}".format(args.outputFile))
+        wb.save(args.outputFile)
+
     print("Done!")
+
+
+
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Hello,

I have run this script inside a pod to collect information about Redis in a production cluster, where for security reasons at the end of the script was not possible to save the file with all the information.
So it was useful for me to have the results printed in the console.
I have done this PR, so maybe with the option -po or --print-only someone else can achieve the same results without the need to create a file. 

