### PR TITLE
Fix duplicated cluster node metrics by querying node endpoints

### DIFF
--- a/osstats.py
+++ b/osstats.py
@@ -141,12 +141,13 @@ async def process_node(section, config, node, is_master_shard, duration):
     Returns:
         command stats output
     """
-    params = node.split(":")
-    print("Processing node {}:{}".format(params[0], params[1]))
+    node_endpoint = node.split("@", 1)[0]
+    node_host, node_port = node_endpoint.rsplit(":", 1)
+    print("Processing node {}:{}".format(node_host, node_port))
 
     client = get_redis_client(
-        host=config.get("host"),
-        port=int(config.get("port", 6379)),
+        host=node_host,
+        port=int(node_port),
         password=config.get("password") or None,
         username=config.get("username") or None,
         tls=config.getboolean("tls", fallback=False),
@@ -170,7 +171,7 @@ async def process_node(section, config, node, is_master_shard, duration):
 
     result["Source"] = "OSS"
     result["ClusterId"] = section
-    result["NodeId"] = params[0].replace(".", "-")
+    result["NodeId"] = node_host.replace(".", "-")
     result["NodeRole"] = "Master" if is_master_shard else "Replica"
     result["RedisVersion"] = info2["redis_version"]
     result["OS"] = info2["os"]

--- a/test_osstats.py
+++ b/test_osstats.py
@@ -132,8 +132,8 @@ class TestProcessNode:
 
         def mock_get(key, default=None, fallback=None):
             values = {
-                "host": "localhost",
-                "port": "6379",
+                "host": "seed-host",
+                "port": "7000",
                 "password": None,
                 "username": None,
                 "ca_cert": None,
@@ -176,12 +176,16 @@ class TestProcessNode:
             {"cmdstat_get": {"calls": 150, "usec": 1500}},
         ]
 
-        result = await process_node("test-section", config, "localhost:6379", True, 1)
+        result = await process_node("test-section", config, "node-1.internal:6380", True, 1)
 
         assert result is not None
         assert result["Source"] == "OSS"
         assert result["ClusterId"] == "test-section"
         assert result["NodeRole"] == "Master"
+        assert result["NodeId"] == "node-1-internal"
+        mock_get_client.assert_called_once()
+        assert mock_get_client.call_args.kwargs["host"] == "node-1.internal"
+        assert mock_get_client.call_args.kwargs["port"] == 6380
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix `process_node` to connect to each node's own host/port parsed from `CLUSTER NODES` output rather than the seed endpoint.
- Prevent duplicated per-node values (memory, command stats, item counts) across all rows in cluster mode.
- Add/adjust unit test assertions to verify `get_redis_client` receives the node endpoint (`node host:port`) and keeps `NodeId` behavior.

## Test plan
- [x] Run `pytest -q`
- [ ] Run `osstats.py` against a 3-master/3-replica cluster and confirm memory/command rows differ per node as expected
- [ ] Validate workbook interpretation: logical dataset size from masters only; replicas are copies for HA

Made with [Cursor](https://cursor.com)