### PR TITLE
Fix cluster mode connecting to wrong nodes

### DIFF
--- a/osstats.py
+++ b/osstats.py
@@ -145,8 +145,8 @@ async def process_node(section, config, node, is_master_shard, duration):
     print("Processing node {}:{}".format(params[0], params[1]))
 
     client = get_redis_client(
-        host=config.get("host"),
-        port=int(config.get("port", 6379)),
+        host=params[0],
+        port=int(params[1]),
         password=config.get("password") or None,
         username=config.get("username") or None,
         tls=config.getboolean("tls", fallback=False),

--- a/osstats.py
+++ b/osstats.py
@@ -155,6 +155,16 @@ async def process_node(section, config, node, is_master_shard, duration):
         client_key=config.get("client_key", fallback=None) or None,
     )
 
+    try:
+        client.ping()
+    except Exception as e:
+        print(
+            "Warning: Cannot connect to cluster node {}:{} - {}".format(
+                params[0], params[1], str(e)
+            )
+        )
+        return None
+
     result = {}
 
     # first run

--- a/test_osstats.py
+++ b/test_osstats.py
@@ -252,6 +252,37 @@ class TestProcessNode:
             client_key=None,
         )
 
+    @pytest.mark.asyncio
+    @patch("osstats.get_redis_client")
+    async def test_process_node_handles_unreachable_node(self, mock_get_client):
+        """Verify that process_node gracefully handles unreachable cluster nodes
+        instead of crashing. This is important when CLUSTER NODES returns
+        internal IPs that aren't reachable from the client."""
+        config = Mock()
+
+        def mock_get(key, default=None, fallback=None):
+            values = {
+                "password": None,
+                "username": None,
+                "ca_cert": None,
+                "client_cert": None,
+                "client_key": None,
+            }
+            return values.get(key, fallback or default)
+
+        config.get.side_effect = mock_get
+        config.getboolean.return_value = False
+
+        mock_client = Mock()
+        mock_client.ping.side_effect = Exception("Connection refused")
+        mock_get_client.return_value = mock_client
+
+        result = await process_node(
+            "test-cluster", config, "10.0.0.5:6379", True, 1
+        )
+
+        assert result is None
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test_osstats.py
+++ b/test_osstats.py
@@ -183,6 +183,75 @@ class TestProcessNode:
         assert result["ClusterId"] == "test-section"
         assert result["NodeRole"] == "Master"
 
+    @pytest.mark.asyncio
+    @patch("osstats.get_redis_client")
+    @patch("osstats.parse_response")
+    @patch("osstats.sleep")
+    async def test_process_node_connects_to_correct_cluster_node(
+        self, mock_sleep, mock_parse, mock_get_client
+    ):
+        """Verify that process_node connects to the actual cluster node address,
+        not the config entry point. This is critical for cluster mode where
+        each node must be queried independently."""
+        config = Mock()
+
+        def mock_get(key, default=None, fallback=None):
+            values = {
+                "host": "entry-point.example.com",
+                "port": "6379",
+                "password": "secret",
+                "username": "admin",
+                "ca_cert": None,
+                "client_cert": None,
+                "client_key": None,
+            }
+            return values.get(key, fallback or default)
+
+        config.get.side_effect = mock_get
+        config.getboolean.return_value = False
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+
+        mock_info_dict = {
+            "redis_version": "6.2.0",
+            "os": "Linux",
+            "total_system_memory": 8589934592,
+            "used_memory_peak": 1048576,
+            "connected_clients": 10,
+            "cluster_enabled": 1,
+            "total_commands_processed": 1000,
+            "db0": {"keys": 100, "expires": 0},
+        }
+        mock_info_dict2 = mock_info_dict.copy()
+        mock_info_dict2["total_commands_processed"] = 1200
+
+        mock_client.execute_command.side_effect = [
+            "cmdstat_get:calls=100,usec=1000",
+            mock_info_dict,
+            "cmdstat_get:calls=150,usec=1500",
+            mock_info_dict2,
+        ]
+
+        mock_parse.side_effect = [
+            {"cmdstat_get": {"calls": 100, "usec": 1000}},
+            {"cmdstat_get": {"calls": 150, "usec": 1500}},
+        ]
+
+        cluster_node = "192.168.1.100:7001"
+        await process_node("test-cluster", config, cluster_node, False, 1)
+
+        mock_get_client.assert_called_once_with(
+            host="192.168.1.100",
+            port=7001,
+            password="secret",
+            username="admin",
+            tls=False,
+            ca_cert=None,
+            client_cert=None,
+            client_key=None,
+        )
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Summary

- Fixed critical bug where `process_node()` in cluster mode was connecting to the config entry point for all nodes instead of the actual cluster node addresses
- This caused all cluster nodes to return identical data (same memoryUsed, same command stats, etc.)
- Added graceful error handling for unreachable cluster nodes (Docker/Kubernetes/VPC scenarios)
- Added regression tests to verify correct behavior

## Problem

When running in cluster mode with multiple nodes (e.g., 3 masters + 3 replicas), the script was:
1. Correctly discovering all cluster nodes via `CLUSTER NODES`
2. Correctly parsing each node's address (host:port)
3. **Incorrectly** connecting to `config.get("host")` and `config.get("port")` instead of the parsed node address

This resulted in:
- All 6 nodes showing identical `memoryUsed` values (e.g., 128,343 for all)
- `SetTypeCmds` appearing on replicas (incorrect - replicas don't process writes)
- Throughput metrics being duplicated 6x instead of showing per-node data
- Incorrect total dataset size calculations

## Fix

**Commit 1**: Changed lines 148-149 in `process_node()`:

```python
# Before (bug):
client = get_redis_client(
    host=config.get("host"),
    port=int(config.get("port", 6379)),
    ...

# After (fix):
client = get_redis_client(
    host=params[0],
    port=int(params[1]),
    ...
```

**Commit 2**: Added graceful error handling for unreachable nodes:
- When `CLUSTER NODES` returns internal IPs (Docker, Kubernetes, private VPCs), those may not be reachable
- Now prints a warning and skips unreachable nodes instead of crashing

## Test plan

- [x] Added `test_process_node_connects_to_correct_cluster_node` - verifies client connects to actual cluster node
- [x] Added `test_process_node_handles_unreachable_node` - verifies graceful handling of connection failures
- [x] All 21 tests pass
- [x] Code formatting verified with `black`