### PR TITLE
Remap cluster node IPs to configured connection host

### DIFF
--- a/osstats.py
+++ b/osstats.py
@@ -789,7 +789,16 @@ def process_database(config, section, workbook, duration, loop):
 
     info = client.execute_command("info")
     if "cluster_enabled" in info and info["cluster_enabled"] == 1:
-        nodes = client.execute_command("cluster nodes")
+        cluster_nodes = client.execute_command("cluster nodes")
+        config_host = config.get("host")
+        nodes = {}
+        for node_addr, stats in cluster_nodes.items():
+            host, port = node_addr.rsplit(":", 1)
+            if host != config_host:
+                remapped_addr = "%s:%s" % (config_host, port)
+                nodes[remapped_addr] = stats
+            else:
+                nodes[node_addr] = stats
     else:
         nodes = {
             "%s:%s"


### PR DESCRIPTION
## Summary
- When connecting to a Redis cluster through port-forwarded localhost (e.g. Docker), `CLUSTER NODES` returns internal container IPs (like `10.0.0.x`) that aren't routable from the host.
- This remaps discovered node addresses to use the original config host, so connections go through the forwarded ports (e.g. `127.0.0.1:7001` instead of `10.0.0.11:7001`).
- Without this, the per-node connection fix from `fix/cluster-node-connection` times out on Docker/NAT setups.

## Test plan
- [x] Tested against a 6-node OSS Redis cluster running in Docker (`redis-scenarios-lab`)
- [x] All 6 nodes (3 masters + 3 replicas) connected successfully via remapped `127.0.0.1` addresses
- [x] Metrics collected and printed without errors

Made with [Cursor](https://cursor.com)